### PR TITLE
add support for dnsmasq based list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -493,9 +493,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "miniz_oxide"
@@ -738,21 +738,20 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -862,6 +861,7 @@ dependencies = [
  "indicatif",
  "log",
  "num-format",
+ "regex",
  "serde",
  "structopt",
  "tempfile",
@@ -977,15 +977,6 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "syn",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
-dependencies = [
- "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ tempfile = "3.2.0"
 thiserror = "1.0.23"
 ureq = "2.0.1"
 url = {version = "2.2.0", features = ["serde"]}
+regex = "1.5.4"

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,6 +54,7 @@ pub(crate) struct Adlist {
 pub(crate) enum AdlistFormat {
     Hosts,
     Domains,
+    DnsMasq,
 }
 
 impl Default for AdlistFormat {


### PR DESCRIPTION
For my use case I am trying to pull from 
```toml
[[adlist]]
source = "https://github.com/notracking/hosts-blocklists/raw/master/dnsmasq/dnsmasq.blacklist.txt"
format = "dnsmasq"

[[output]]
type = "hosts"
destination = "generated-hosts"
blackhole-address = "0.0.0.0"
```
Perusing [the repo](https://github.com/notracking/hosts-blocklists) it looks a variety of daemon configs are produced but nothing as straightforward as a simple hosts file. As such, I want to augment the app to parse the dnsmasq config format and then be able to use this as a source.

```powershell
PS> cargo run --release -- -c .\target\release\singularity.toml
    Finished release [optimized] target(s) in 0.09s
     Running `target\release\singularity.exe -c .\target\release\singularity.toml`
⠙ 0 domains read so far...
⠂ 0 domains read so far...
INFO Reading adlist from https://github.com/notracking/hosts-blocklists/raw/master/dnsmasq/dnsmasq.blacklist.txt...
INFO Read 250,241 domains from 1 source(s)
cat .\generated-hosts -Head 6
# Generated at 2021-12-29 17:14:09.666248800 -08:00 with singularity v0.7.0
0.0.0.0 0--e.info
0.0.0.0 0-0.fr
0.0.0.0 0-132.net.daraz.com
0.0.0.0 0-800-email.com
0.0.0.0 0-day.us
```