### PR TITLE
match blackhole_address to example config field name

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,7 @@ pub(crate) struct OutputConfig {
     #[serde(flatten)]
     pub ty: OutputConfigType,
     pub destination: PathBuf,
+    #[serde(rename = "blackhole-address")]
     #[serde(default = "default_blackhole_address")]
     pub blackhole_address: IpAddr,
 }


### PR DESCRIPTION
In the docs for the config `blackhole-address` is used however the config is actually looking for `blackhole_address`. For instance,
```powershell
PS> cat .\broken.toml
[[adlist]]
source = "https://github.com/notracking/hosts-blocklists/raw/master/dnsmasq/dnsmasq.blacklist.txt"
format = "dnsmasq"

[[output]]
type = "hosts"
destination = "generated-hosts"
blackhole-address = "1.2.3.4"
PS> cargo run --release -- -c .\broken.toml
    Finished release [optimized] target(s) in 0.08s
     Running `target\release\singularity.exe -c .\broken.toml`
⠁ 0 domains read so far...
⠙ 0 domains read so far...
INFO Reading adlist from https://github.com/notracking/hosts-blocklists/raw/master/dnsmasq/dnsmasq.blacklist.txt...
INFO Read 250,241 domains from 1 source(s)
PS> cat .\generated-hosts -Head 6
# Generated at 2021-12-29 17:34:26.980989700 -08:00 with singularity v0.7.0
0.0.0.0 0--e.info
0.0.0.0 0-0.fr
0.0.0.0 0-132.net.daraz.com
0.0.0.0 0-800-email.com
0.0.0.0 0-day.us
```

However, supplying the right incantation in the `toml` config will do the right thing
```powershell
PS> cat .\working.toml
[[adlist]]
source = "https://github.com/notracking/hosts-blocklists/raw/master/dnsmasq/dnsmasq.blacklist.txt"
format = "dnsmasq"

[[output]]
type = "hosts"
destination = "generated-hosts"
"blackhole_address" = "1.2.3.4"
PS> cargo run --release -- -c .\working.toml
    Finished release [optimized] target(s) in 0.09s
     Running `target\release\singularity.exe -c .\working.toml`
⠁ 0 domains read so far...
⠙ 0 domains read so far...
INFO Reading adlist from https://github.com/notracking/hosts-blocklists/raw/master/dnsmasq/dnsmasq.blacklist.txt...
INFO Read 250,241 domains from 1 source(s)
PS> cat .\generated-hosts -Head 6
# Generated at 2021-12-29 17:35:39.114433 -08:00 with singularity v0.7.0
1.2.3.4 0--e.info
1.2.3.4 0-0.fr
1.2.3.4 0-132.net.daraz.com
1.2.3.4 0-800-email.com
1.2.3.4 0-day.us
```

Annotating the field further will achieve the behavior specified in the documentation:
```powershell
PS> cat .\broken.toml                      
[[adlist]]
source = "https://github.com/notracking/hosts-blocklists/raw/master/dnsmasq/dnsmasq.blacklist.txt"
format = "dnsmasq"

[[output]]
type = "hosts"
destination = "generated-hosts"
blackhole-address = "1.2.3.4"
PS> cargo run --release -- -c .\broken.toml 
   Compiling singularity v0.7.0
    Finished release [optimized] target(s) in 3.72s
     Running `target\release\singularity.exe -c .\broken.toml`
⠙ 0 domains read so far...
⠂ 0 domains read so far...
INFO Reading adlist from https://github.com/notracking/hosts-blocklists/raw/master/dnsmasq/dnsmasq.blacklist.txt...
INFO Read 250,241 domains from 1 source(s)
PS> cat .\generated-hosts -Head 6
# Generated at 2021-12-29 17:40:04.353233800 -08:00 with singularity v0.7.0
1.2.3.4 0--e.info
1.2.3.4 0-0.fr
1.2.3.4 0-132.net.daraz.com
1.2.3.4 0-800-email.com
1.2.3.4 0-day.us
```
