### PR TITLE
adjust error handling to tell the user why no domains were processed

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -93,7 +93,10 @@ impl Adlist {
                 };
                 let len: u64 = resp
                     .header("Content-Length")
-                    .ok_or(SingularityError::MissingContentLengthHeader)?
+                    .ok_or_else(|| {
+                        warn!("expected content-length but did not see it, not processing {}", self.source);
+                        SingularityError::MissingContentLengthHeader
+                    })?
                     .parse()?;
                 debug!("Got response status {} with len {}", resp.status(), len);
                 Ok((len, Box::new(resp.into_reader()) as Box<dyn Read>))


### PR DESCRIPTION
I spent a bit of time figuring out why [this source](https://v.firebog.net/hosts/neohostsbasic.txt) didn't produce any hits for domains.

Checking with `curl` there is no `Content-Length` header returned in the web request:
```powershell
PS> curl.exe --HEAD --raw -iv https://v.firebog.net/hosts/neohostsbasic.txt 2>&1 | sls content

< Content-Type: text/plain
Content-Type: text/plain
```

As such, the code is currently failing silently without telling the user that something is wrong with the source. This change will adjust the code such that it will tell the user something it expects isn't there instead of failing silently.

```powershell
PS> cat .\fail-louder.toml
[[adlist]]
source = "https://v.firebog.net/hosts/neohostsbasic.txt"
format = "domains"

[[output]]
type = "hosts"
destination = "generated-hosts"
blackhole-address = "0.0.0.0"
PS> PS D:\code\ad-blocklist-sync\Singularity> cargo run --release -- -c .\fail-louder.toml
    Finished release [optimized] target(s) in 0.09s
     Running `target\release\singularity.exe -c .\fail-louder.toml`
⠁ 0 domains read so far...
⠉ 0 domains read so far...
WARN expected content-length but did not see it, not processing https://v.firebog.net/hosts/neohostsbasic.txt
INFO Read 0 domains from 1 source(s)
```