### PR TITLE
add feature to dedupe the list of redundant domains

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,8 @@ pub(crate) struct OutputConfig {
     pub destination: PathBuf,
     #[serde(default = "default_blackhole_address")]
     pub blackhole_address: IpAddr,
+    #[serde(default = "default_deduplicate")]
+    pub deduplicate: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -74,6 +76,10 @@ fn default_output_metric() -> bool {
 
 fn default_metric_name() -> String {
     String::from("blocked-queries")
+}
+
+fn default_deduplicate() -> bool {
+    false
 }
 
 impl Adlist {


### PR DESCRIPTION
These lists can get pretty big. As such I'd like to cut down on duplicate entries and wanted to add a toggle to turn deduping the lists on or off depending on your preference.

This config takes a handful of sources 
```powershell
PS> cat .\dedupe.toml                         
[[adlist]]
source = "https://github.com/notracking/hosts-blocklists/raw/master/dnsmasq/dnsmasq.blacklist.txt"
format = "dnsmasq"

[[adlist]]
source = "https://someonewhocares.org/hosts/zero/hosts"
format = "hosts"

[[adlist]]
source = "https://raw.githubusercontent.com/VeleSila/yhosts/master/hosts"
format = "hosts"

[[output]]
type = "hosts"
destination = "generated-hosts"
blackhole-address = "0.0.0.0"

[[output]]
type = "hosts"
destination = "generated-hosts-ipv6"
blackhole-address = "::"
deduplicate = true
```

We get out 2 big lists of domains for IPv4 and IPv6.
```
PS> cargo run --release -- -c .\dedupe.toml   
   Compiling singularity v0.7.0 (D:\code\ad-blocklist-sync\Singularity)
    Finished release [optimized] target(s) in 3.77s
     Running `target\release\singularity.exe -c .\dedupe.toml`
⠁ 0 domains read so far...
INFO sending request GET https://raw.githubusercontent.com/VeleSila/yhosts/master/hosts
INFO Reading adlist from https://raw.githubusercontent.com/VeleSila/yhosts/master/hosts...
⠉ 2500 domains read so far...
INFO Reading adlist from https://someonewhocares.org/hosts/zero/hosts...
⠂ 6256 domains read so far...
INFO Reading adlist from https://github.com/notracking/hosts-blocklists/raw/master/dnsmasq/dnsmasq.blacklist.txt...
INFO Read 273,445 domains from 3 source(s)
```

From the above config, the IPv6 list is deduped, so we should not see duplicate entries with the goatman:
```powershell
PS> cat .\generated-hosts-ipv6 | sls goatse.cx

:: goatse.cx
:: www.goatse.cx


PS> cat .\generated-hosts | sls goatse.cx

0.0.0.0 goatse.cx
0.0.0.0 www.goatse.cx
0.0.0.0 goatse.cx
```

This reduces the overall amount of entries by a bit
```powershell
PS> (cat .\generated-hosts-ipv6).Length - 1
267124
PS> (cat .\generated-hosts).Length - 1
273445
PS> ((cat .\generated-hosts).Length - 1) - ((cat .\generated-hosts-ipv6).Length - 1)
6321
```